### PR TITLE
Add ASCII art for IMPLOID at CLI startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@
 
 import { Command } from 'commander';
 import { greet } from './commands/greet';
+import { displayImploidAsciiArt } from './utils/asciiArt';
+
+displayImploidAsciiArt();
 
 const program = new Command();
 

--- a/src/utils/asciiArt.test.ts
+++ b/src/utils/asciiArt.test.ts
@@ -1,0 +1,36 @@
+import { displayImploidAsciiArt } from './asciiArt';
+
+describe('asciiArt', () => {
+  describe('displayImploidAsciiArt', () => {
+    it('should display ASCII art for IMPLOID', () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      
+      displayImploidAsciiArt();
+      
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      const callArg = consoleSpy.mock.calls[0][0] as string;
+      expect(callArg).toContain('___');
+      expect(callArg).toContain('|');
+      expect(callArg).toMatch(/___.*___/s);
+      
+      consoleSpy.mockRestore();
+    });
+
+    it('should contain the word IMPLOID in ASCII art format', () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      
+      displayImploidAsciiArt();
+      
+      const callArg = consoleSpy.mock.calls[0][0] as string;
+      expect(callArg).toMatch(/[I|_]/);
+      expect(callArg).toMatch(/[M|\\|/]/);
+      expect(callArg).toMatch(/[P|_]/);
+      expect(callArg).toMatch(/[L|_]/);
+      expect(callArg).toMatch(/[O|_]/);
+      expect(callArg).toMatch(/[I|_]/);
+      expect(callArg).toMatch(/[D|_]/);
+      
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/utils/asciiArt.ts
+++ b/src/utils/asciiArt.ts
@@ -1,0 +1,13 @@
+export function displayImploidAsciiArt(): void {
+  const asciiArt = `
+ _____ __  __ _____  _      ____ _____ _____  
+|_   _|  \\/  |  __ \\| |    / __ \\_   _|  __ \\ 
+  | | | \\  / | |__) | |   | |  | || | | |  | |
+  | | | |\\/| |  ___/| |   | |  | || | | |  | |
+ _| |_| |  | | |    | |___| |__| || |_| |__| |
+|_____|_|  |_|_|    |______\\____/_____|_____/ 
+  `;
+  
+  // eslint-disable-next-line no-console
+  console.log(asciiArt);
+}


### PR DESCRIPTION
## Summary
- Created ASCII art display function for IMPLOID text
- Integrated ASCII art to show at CLI startup
- Added comprehensive unit tests for the ASCII art functionality

## Test plan
- [x] Run `npm run test` - all tests pass
- [x] Run `npm run lint` - no linting errors
- [x] Run `npm run build` - builds successfully
- [x] Run `node dist/index.js --help` - displays ASCII art before help menu
- [x] Verify ASCII art shows "IMPLOID" text clearly

Resolves #5

🤖 Generated with [Claude Code](https://claude.ai/code)